### PR TITLE
Browser history

### DIFF
--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -40,7 +40,11 @@ class CourseList extends React.Component {
   }
 
   componentDidMount() {
-    this.fetchInfoUpdateState('courseCode', false, '', 0);
+    if (this.props.location.state) {
+      this.setState(this.props.location.state);
+    } else {
+      this.fetchInfoUpdateState('courseCode', false, '', 0);
+    }
     window.onpopstate = () => {
       this.setState(this.props.history.location.state);
     };

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -61,14 +61,14 @@ class CourseList extends React.Component {
       <nav className="pagination is-centered" role="navigation" aria-label="pagination">
         <ul className="pagination-list">
           { prev > first &&
-              <>
               <li>
                 <a onClick={ () => this.changePage(first-1) } className="pagination-link" aria-label="Page { first }" aria-current="page">{ first }</a>
-              </li> 
+              </li> }
+          { prev - 1 > first &&
               <li>
                 <span class="pagination-ellipsis">&hellip;</span>
               </li> 
-              </> }
+          }
           { prev > 0 &&
               <li>
                 <a onClick={ () => this.changePage(prev-1) } className="pagination-link" aria-label="Page { prev }" aria-current="page">{ prev }</a>
@@ -80,15 +80,15 @@ class CourseList extends React.Component {
               <li>
                 <a onClick={ () => this.changePage(next-1) } className="pagination-link" aria-label="Page { this.state.page + 2 }" aria-current="page">{ next }</a>
               </li> }
-          { next < pages &&
-              <>
+          { next < pages-1 &&
               <li>
                 <span class="pagination-ellipsis">&hellip;</span>
-              </li>
+              </li> }
+          { next < pages &&
               <li>
                 <a onClick={ () => this.changePage(pages-1) } className="pagination-link" aria-label="Page { pages }" aria-current="page">{ pages }</a>
               </li>
-              </> }
+           }
             </ul>
           </nav>);
   }

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -42,7 +42,6 @@ class CourseList extends React.Component {
   componentDidMount() {
     this.fetchInfoUpdateState('courseCode', false, '', 0);
     window.onpopstate = () => {
-      console.log(this.props.history);
       this.setState(this.props.history.location.state);
     };
   }

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -66,7 +66,7 @@ class CourseList extends React.Component {
               </li> }
           { prev - 1 > first &&
               <li>
-                <span class="pagination-ellipsis">&hellip;</span>
+                <span className="pagination-ellipsis">&hellip;</span>
               </li> 
           }
           { prev > 0 &&
@@ -82,7 +82,7 @@ class CourseList extends React.Component {
               </li> }
           { next < pages-1 &&
               <li>
-                <span class="pagination-ellipsis">&hellip;</span>
+                <span className="pagination-ellipsis">&hellip;</span>
               </li> }
           { next < pages &&
               <li>

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -32,7 +32,7 @@ class CourseList extends React.Component {
   sorter(sortee) {
     let order;
     if (sortee === this.state.sort) {
-      order = !this.state.order;
+      order = !this.state.desc;
     } else {
       if (sortee === 'courseName' || sortee === 'courseCode' || sortee === 'programShort') {
         order = false;

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -22,7 +22,7 @@ class CourseList extends React.Component {
   fetchInfo(sortee, order, matchee, page) {
     fetch(process.env.PUBLIC_URL+'/courses?sort=' + sortee + '_' + dict[order] + '&search=' + matchee + '&page=' + page + '&items=' + items_per_page)
       .then(res => res.json())
-      .then(data => data.courses.length && data.metadata.length && this.setState({ data: data.courses, sort: sortee, order: order, match: matchee, page: page, count: data.metadata[0].count }));
+      .then(data => data.courses.length && data.metadata.length && this.setState({ data: data.courses, sort: sortee, desc: order, match: matchee, page: page, count: data.metadata[0].count }));
   }
 
   componentDidMount() {

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -51,14 +51,24 @@ class CourseList extends React.Component {
     let pages = this.state.count/items_per_page;
     let rest = this.state.count%items_per_page;
     if (rest > 0) {
-      pages += 1;
+      pages = Math.floor(pages+1);
     }
+    let first = 1
     let prev = this.state.page;
     let current = this.state.page + 1;
     let next = this.state.page + 2;
     return (
       <nav className="pagination is-centered" role="navigation" aria-label="pagination">
         <ul className="pagination-list">
+          { prev > first &&
+              <>
+              <li>
+                <a onClick={ () => this.changePage(first-1) } className="pagination-link" aria-label="Page { first }" aria-current="page">{ first }</a>
+              </li> 
+              <li>
+                <span class="pagination-ellipsis">&hellip;</span>
+              </li> 
+              </> }
           { prev > 0 &&
               <li>
                 <a onClick={ () => this.changePage(prev-1) } className="pagination-link" aria-label="Page { prev }" aria-current="page">{ prev }</a>
@@ -66,12 +76,21 @@ class CourseList extends React.Component {
               <li>
                 <a className="pagination-link is-current" aria-label="Page { current }" aria-current="page">{ current }</a>
               </li>
-              { next <= pages &&
-                  <li>
-                    <a onClick={ () => this.changePage(next-1) } className="pagination-link" aria-label="Page { this.state.page + 2 }" aria-current="page">{ next }</a>
-                  </li> }
-                </ul>
-              </nav>);
+          { next <= pages &&
+              <li>
+                <a onClick={ () => this.changePage(next-1) } className="pagination-link" aria-label="Page { this.state.page + 2 }" aria-current="page">{ next }</a>
+              </li> }
+          { next < pages &&
+              <>
+              <li>
+                <span class="pagination-ellipsis">&hellip;</span>
+              </li>
+              <li>
+                <a onClick={ () => this.changePage(pages-1) } className="pagination-link" aria-label="Page { pages }" aria-current="page">{ pages }</a>
+              </li>
+              </> }
+            </ul>
+          </nav>);
   }
 
 

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -20,7 +20,7 @@ class CourseList extends React.Component {
   }
 
   fetchInfo(sortee, order, matchee, page) {
-    fetch(process.env.PUBLIC_URL+'/courses?sort=' + sortee + '_' + dict[order] + '&search=' + matchee + '&page=' + page + '&items=' + items_per_page)
+    fetch(`${process.env.PUBLIC_URL}/courses?sort=${sortee}_${dict[order]}&search=${matchee}&page=${page}&items=${items_per_page}`)
       .then(res => res.json())
       .then(data => data.courses.length && data.metadata.length && this.setState({ data: data.courses, sort: sortee, desc: order, match: matchee, page: page, count: data.metadata[0].count }));
   }

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -29,7 +29,7 @@ class CourseList extends React.Component {
       tempState.match = matchee;
       tempState.page = page;
       tempState.count = data.metadata[0].count;
-      this.props.history.push('/stats', tempState);
+      this.props.history.push('/stats/', tempState);
     }
   }
 

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -29,7 +29,7 @@ class CourseList extends React.Component {
       tempState.match = matchee;
       tempState.page = page;
       tempState.count = data.metadata[0].count;
-      this.props.history.push(process.env.PUBLIC_URL+'/stats', tempState);
+      this.props.history.push('/stats', tempState);
     }
   }
 

--- a/src/CourseList.js
+++ b/src/CourseList.js
@@ -19,14 +19,32 @@ class CourseList extends React.Component {
     this.timeout = 0;
   }
 
-  fetchInfo(sortee, order, matchee, page) {
-    fetch(`${process.env.PUBLIC_URL}/courses?sort=${sortee}_${dict[order]}&search=${matchee}&page=${page}&items=${items_per_page}`)
-      .then(res => res.json())
-      .then(data => data.courses.length && data.metadata.length && this.setState({ data: data.courses, sort: sortee, desc: order, match: matchee, page: page, count: data.metadata[0].count }));
+  async fetchInfoUpdateState(sortee, order, matchee, page) {
+    const data = await this.fetchInfo(sortee, order, matchee, page);
+    if (data.courses.length && data.metadata.length) {
+      let tempState = this.state;
+      tempState.data = data.courses;
+      tempState.sort = sortee;
+      tempState.desc = order;
+      tempState.match = matchee;
+      tempState.page = page;
+      tempState.count = data.metadata[0].count;
+      this.props.history.push(process.env.PUBLIC_URL+'/stats', tempState);
+    }
+  }
+
+  async fetchInfo(sortee, order, matchee, page) {
+    const response = await fetch(`${process.env.PUBLIC_URL}/courses?sort=${sortee}_${dict[order]}&search=${matchee}&page=${page}&items=${items_per_page}`);
+    const json = await response.json();
+    return json;
   }
 
   componentDidMount() {
-    this.fetchInfo('courseCode', false, '', 0);
+    this.fetchInfoUpdateState('courseCode', false, '', 0);
+    window.onpopstate = () => {
+      console.log(this.props.history);
+      this.setState(this.props.history.location.state);
+    };
   }
 
   sorter(sortee) {
@@ -40,11 +58,11 @@ class CourseList extends React.Component {
         order = true;
       }
     }
-    this.fetchInfo(sortee, order, this.state.match, this.state.page);
+    this.fetchInfoUpdateState(sortee, order, this.state.match, this.state.page);
   }
 
   changePage(page) {
-    this.fetchInfo(this.state.sort, this.state.desc, this.state.match, page);
+    this.fetchInfoUpdateState(this.state.sort, this.state.desc, this.state.match, page);
   }
 
   navigation() {
@@ -58,39 +76,38 @@ class CourseList extends React.Component {
     let current = this.state.page + 1;
     let next = this.state.page + 2;
     return (
-      <nav className="pagination is-centered" role="navigation" aria-label="pagination">
-        <ul className="pagination-list">
-          { prev > first &&
-              <li>
-                <a onClick={ () => this.changePage(first-1) } className="pagination-link" aria-label="Page { first }" aria-current="page">{ first }</a>
-              </li> }
-          { prev - 1 > first &&
-              <li>
-                <span className="pagination-ellipsis">&hellip;</span>
-              </li> 
-          }
-          { prev > 0 &&
-              <li>
-                <a onClick={ () => this.changePage(prev-1) } className="pagination-link" aria-label="Page { prev }" aria-current="page">{ prev }</a>
-              </li> }
-              <li>
-                <a className="pagination-link is-current" aria-label="Page { current }" aria-current="page">{ current }</a>
-              </li>
-          { next <= pages &&
-              <li>
-                <a onClick={ () => this.changePage(next-1) } className="pagination-link" aria-label="Page { this.state.page + 2 }" aria-current="page">{ next }</a>
-              </li> }
-          { next < pages-1 &&
-              <li>
-                <span className="pagination-ellipsis">&hellip;</span>
-              </li> }
-          { next < pages &&
-              <li>
-                <a onClick={ () => this.changePage(pages-1) } className="pagination-link" aria-label="Page { pages }" aria-current="page">{ pages }</a>
-              </li>
-           }
-            </ul>
-          </nav>);
+    <nav className="pagination is-centered" role="navigation" aria-label="pagination">
+      <ul className="pagination-list">
+      { prev > first &&
+        <li>
+          <a onClick={ () => this.changePage(first-1) } className="pagination-link" aria-label="Page { first }" aria-current="page">{ first }</a>
+        </li> }
+      { prev - 1 > first &&
+        <li>
+        <span className="pagination-ellipsis">&hellip;</span>
+        </li> }
+      { prev > 0 &&
+        <li>
+        <a onClick={ () => this.changePage(prev-1) } className="pagination-link" aria-label="Page { prev }" aria-current="page">{ prev }</a>
+        </li> }
+        <li>
+        <a className="pagination-link is-current" aria-label="Page { current }" aria-current="page">{ current }</a>
+        </li>
+      { next <= pages &&
+        <li>
+        <a onClick={ () => this.changePage(next-1) } className="pagination-link" aria-label="Page { this.state.page + 2 }" aria-current="page">{ next }</a>
+        </li> }
+      { next < pages-1 &&
+        <li>
+        <span className="pagination-ellipsis">&hellip;</span>
+        </li> }
+      { next < pages &&
+        <li>
+        <a onClick={ () => this.changePage(pages-1) } className="pagination-link" aria-label="Page { pages }" aria-current="page">{ pages }</a>
+        </li>
+        }
+      </ul>
+    </nav>);
   }
 
 
@@ -101,7 +118,7 @@ class CourseList extends React.Component {
       }
       const query = event.target.value;
       this.timeout = setTimeout(() => {
-        this.fetchInfo(this.state.sort, this.state.desc, query, 0);
+        this.fetchInfoUpdateState(this.state.sort, this.state.desc, query, 0);
       }, 500);
     };
     return (<input className="input" type="text" placeholder="Search" onChange={handleChange} />);

--- a/statistics/controller/courseController.js
+++ b/statistics/controller/courseController.js
@@ -32,7 +32,6 @@ exports.courseList = ((req, res) => {
   if (req.query.page) {
     page = parseInt(req.query.page);
   }
-  console.log(page);
   if (req.query.items) {
     items = parseInt(req.query.items);
   }
@@ -73,7 +72,6 @@ exports.courseList = ((req, res) => {
       'metadata': [ {$group:  {_id: null, count: { $sum: 1 } } }, {$project: {_id: 0} } ],
     } },
   ], (err, result) => {
-    console.log(result[0]);
     res.json(result[0]);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/Fysikteknologsektionen/chalmers-course-stats/issues/20. Every update in the main page gets saved in the browser history. Now you are able to iterate through each change. Coming back from a detailed course view lets you resume your previous query.