### PR TITLE
Implemented basic type filtering

### DIFF
--- a/src/Statistics.js
+++ b/src/Statistics.js
@@ -140,7 +140,7 @@ class Statistics extends React.Component {
       } else if (this.state.exams || this.state.misc) {
         let bool = (item) => item.type.includes('Tentamen');
         if (this.state.misc) {
-          let bool = (item) => !item.type.includes('Tentamen');
+          bool = (item) => !item.type.includes('Tentamen');
         }
         this.state.data.map(item => {
           if (bool(item))

--- a/src/Statistics.js
+++ b/src/Statistics.js
@@ -18,6 +18,8 @@ class Statistics extends React.Component {
       expand: 'none',
       data: null,
       info: null,
+      exams: true,
+      misc: true,
     };
   }
 
@@ -114,20 +116,48 @@ class Statistics extends React.Component {
           <input type="radio" name="setting" onClick={() => this.setState({ expand: 'expand' })} />
           Normalized
         </label>
+        &nbsp;
+        <label className="checkbox">
+          <input type="checkbox" defaultChecked={this.state.exams} onClick={() => this.setState({ exams: !this.state.exams })}/>
+          Show exams
+        </label>
+        &nbsp;
+        <label className="checkbox">
+          <input type="checkbox" defaultChecked={this.state.misc} onClick={() => this.setState({ misc: !this.state.misc })}/>
+          Show misc
+        </label>
       </div>
     );
 
     const grades = ['U', '3', 'G', 'TG', '4', '5'];
     const colors = {'U': 'hsl(20, 90%, 40%)', '3': 'hsl(100, 60%, 80%)', 'G': 'hsl(100, 60%, 80%)', 'TG': 'hsl(100, 60%, 80%)', '4': 'hsl(100, 60%, 60%)', '5': 'hsl(100, 60%, 40%)'};    
+
+    let filtered = [];
+    if (this.state.data) {
+      if (this.state.exams && this.state.misc) {
+        filtered = this.state.data;
+
+      } else if (this.state.exams || this.state.misc) {
+        let bool = (item) => item.type.includes('Tentamen');
+        if (this.state.misc) {
+          let bool = (item) => !item.type.includes('Tentamen');
+        }
+        this.state.data.map(item => {
+          if (bool(item))
+            filtered.push(item);
+          }
+        );
+      }
+    }
     return (
       <div className="container">
         { this.renderInput(this.handleChange) }
         { InfoBar }
         { radio }
-        { this.state.info && this.state.data &&
-          <ResponsiveContainer width="100%" height={Math.max(Object.keys(this.state.data).length * 40, 300)}>
+        { this.state.info && filtered &&
+          <ResponsiveContainer width="100%" height={Math.max(Object.keys(filtered).length * 40, 300)}>
             <BarChart
-              data={this.state.data}
+              data={filtered}
               layout="vertical"
               margin={{ top: 20, right: 40, left: 40, bottom: 5 }}
               stackOffset={this.state.expand}


### PR DESCRIPTION
As suggested by https://github.com/Fysikteknologsektionen/chalmers-course-stats/issues/18. However, there are many different types of results beyond exams and projects. Additional work can be done by adding the result type into the tooltips and even more options for filtering. If additional options are added something like a boolean array should be used.

The database has to be rebuilt for this branch since the type was not stored in previous version of the schemas.