### PR TITLE
Compose file proposal - no dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+
+services:
+  db:
+    image: mongo:4.4.14-rc0
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: stats
+    volumes:
+      - db-data:/data/db
+      # To create a database, we mount a small mongo script
+      # See "Initializing a fresh instance" at https://hub.docker.com/_/mongo
+      - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    networks:
+      - back-tier
+  app:
+    image: node:16.15-bullseye
+    restart: unless-stopped
+    working_dir: /usr/src/app
+    command:
+      - /bin/sh
+      - -c
+      - |
+        # Install docker-compose wait
+        curl -L https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait -o /wait
+        chmod +x /wait
+        # Copy the repository files from the bind mount to a local folder inside the container
+        # This leavs the files outside the container untouched and increases io performance
+        cp -r /usr/src/repo/. .
+        # Create a production build
+        npm ci
+        npm run build
+        # Wait for mongo to be ready
+        WAIT_HOSTS="$${DB_HOST}:$${DB_PORT}" /wait
+        # Populate the database
+        npm run db
+        # Start the server
+        node server.js
+    environment:
+      APP_HOST: '0.0.0.0'
+      APP_PORT: ${STATS_PORT}
+      DB_HOST: db
+      DB_PORT: 27017
+      DB_DATABASE: stats
+      DB_USER: stats
+      DB_PASSWORD: password
+    volumes:
+      - .:/usr/src/repo:ro
+      - ${STATS_DOCUMENTS}:/usr/src/repo/statistics/documents:ro
+    networks:
+      - public
+      - back-tier
+
+volumes:
+  db-data:
+
+networks:
+  back-tier:
+  public:
+    external: true
+    name: ${STATS_NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     networks:
       - back-tier
-  app:
+  chalmers-course-stats:
     image: node:16.15-bullseye
     restart: unless-stopped
     working_dir: /usr/src/app
@@ -50,7 +50,7 @@ services:
       - .:/usr/src/repo:ro
       - ${STATS_DOCUMENTS}:/usr/src/repo/statistics/documents:ro
     networks:
-      - public
+      - front-tier
       - back-tier
 
 volumes:
@@ -58,6 +58,6 @@ volumes:
 
 networks:
   back-tier:
-  public:
-    external: true
-    name: ${STATS_NETWORK}
+  front-tier:
+    external: ${STATS_NET_EXTERN:-false}
+    name: ${STATS_NET_NAME:-front-tier}

--- a/mongo-init.js
+++ b/mongo-init.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: "stats",
+  pwd: "password",
+  roles: [
+    {
+      role: "readWrite",
+      db: "stats",
+    },
+  ],
+});


### PR DESCRIPTION
In order to migrate to docker, this pull request proposes a production ready docker-compose file.

This proposal does not contain any docker file but instead utilizes the ready made node image, setting the entrypoint to install dependencies, build the app, initialize the database and finally run the server.

An alternate approach would be to install dependencies and build inside a custom dockerfile. However, this dockerfile would probably not be possible to reuse for a future devcontainer. As to keep files added to the repo to a minimum we opt to use docker-compose to build the app instead.

Another possible area of improvement in this proposal is the network configuration. The way it is currently set up, if we want to put the stats app behind a reverse proxy - nginx for example - we would create a new network for nginx called e.g. `nginx-network`, and specify `STATS_NET_EXTERN=true`, `STATS_NET_NAME=nginx-network` and for example `STATS_PORT=3000`. Now nginx would be able to proxy requests for the stats app to `http://chalmers-course-stats:3000` over `nginx-network`.